### PR TITLE
Added a layover popup from MailChimp which will appear after 2 seconds.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -83,5 +83,8 @@
 
 <div ui-view></div>
 
+
+<script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script>
+<script type="text/javascript">require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us13.list-manage.com","uuid":"eadfe47d068d375297cc2f34c","lid":"8dbcaa462e"}) })</script>
 </body>
 </html>


### PR DESCRIPTION
This popup asks the user to fill in his email address (optionally of course).

It will only appear once per browser. If you close it, it will remember that you closed it using a cookie.
This way we won't bother users too often with the same question.
