### PR TITLE
Moved the googleTagManager code from the main.html to the index.html.

### DIFF
--- a/src/app/general/googleTagManager.html
+++ b/src/app/general/googleTagManager.html
@@ -1,9 +1,0 @@
-<!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WCRT4P"
-                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-WCRT4P');</script>
-<!-- End Google Tag Manager -->

--- a/src/app/main.controller.js
+++ b/src/app/main.controller.js
@@ -31,7 +31,6 @@ angular
         basePage.template = {
             summonerSelector: 'app/summoner/summoner.html',
             statistics: 'app/statistics/statistics.html',
-            googleTagManager: 'app/general/googleTagManager.html'
         };
     }
 })();

--- a/src/app/main.html
+++ b/src/app/main.html
@@ -1,6 +1,5 @@
 <div id="container">
     <div id="body">
-        <div ng-include="main.template.googleTagManager"></div>
         <div ng-include="main.template.summonerSelector" ng-controller="SummonerPageCtrl as summoner"></div>
 
         <div ui-view></div>

--- a/src/index.html
+++ b/src/index.html
@@ -80,6 +80,15 @@
     </script>
 </head>
 <body>
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WCRT4P"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WCRT4P');</script>
+<!-- End Google Tag Manager -->
 
 <div ui-view></div>
 


### PR DESCRIPTION
The reason behind this is because GTM is supposed to be place directly after the body element. I also removed the ng-include as this only implies more unnecessary logic and possibly issues as GTM is not meant to be loaded that way.

Source:
https://support.google.com/tagassistant/answer/3207128?ref_topic=2947092#script_flow
